### PR TITLE
URL Cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,11 +40,11 @@
 			<repositories>
 				<repository>
 					<id>spring-libs-snapshot</id>
-					<url>http://repo.springsource.org/libs-snapshot</url>
+					<url>https://repo.springsource.org/libs-snapshot</url>
 				</repository>
 				<repository>
 					<id>neo4j-public-release-repository</id>
-					<url>http://m2.neo4j.org/releases</url>
+					<url>https://m2.neo4j.org/releases</url>
 				</repository>
 			</repositories>
 
@@ -63,7 +63,7 @@
 			<repositories>
 				<repository>
 					<id>spring-libs-snapshot</id>
-					<url>http://repo.springsource.org/libs-snapshot</url>
+					<url>https://repo.springsource.org/libs-snapshot</url>
 				</repository>
 			</repositories>
 
@@ -85,7 +85,7 @@
 			<repositories>
 				<repository>
 					<id>spring-libs-milestone</id>
-					<url>http://repo.springsource.org/libs-milestone</url>
+					<url>https://repo.springsource.org/libs-milestone</url>
 					<snapshots>
 						<enabled>false</enabled>
 					</snapshots>
@@ -140,7 +140,7 @@
 			<repositories>
 				<repository>
 					<id>spring-libs-milestone</id>
-					<url>http://repo.springsource.org/libs-milestone</url>
+					<url>https://repo.springsource.org/libs-milestone</url>
 				</repository>
 			</repositories>
 		</profile>
@@ -153,7 +153,7 @@
 			<repositories>
 				<repository>
 					<id>spring-libs-snapshot</id>
-					<url>http://repo.springsource.org/libs-snapshot</url>
+					<url>https://repo.springsource.org/libs-snapshot</url>
 				</repository>
 			</repositories>
 		</profile>
@@ -337,7 +337,7 @@
 	<repositories>
 		<repository>
 			<id>neo4j-public-release-repository</id>
-			<url>http://m2.neo4j.org/releases</url>
+			<url>https://m2.neo4j.org/releases</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://m2.neo4j.org/releases (404) migrated to:  
  https://m2.neo4j.org/releases ([https](https://m2.neo4j.org/releases) result 404).

## Fixed Success 
These URLs were fixed successfully.

* http://repo.springsource.org/libs-milestone migrated to:  
  https://repo.springsource.org/libs-milestone ([https](https://repo.springsource.org/libs-milestone) result 301).
* http://repo.springsource.org/libs-snapshot migrated to:  
  https://repo.springsource.org/libs-snapshot ([https](https://repo.springsource.org/libs-snapshot) result 301).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0
* http://maven.apache.org/xsd/maven-4.0.0.xsd
* http://www.w3.org/2001/XMLSchema-instance